### PR TITLE
Fix duplicate logger handlers

### DIFF
--- a/gx_mcp_server/__init__.py
+++ b/gx_mcp_server/__init__.py
@@ -5,12 +5,15 @@ from fastmcp import FastMCP
 
 # Configure logger
 logger = logging.getLogger("gx_mcp_server")
-handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+
+# Avoid adding multiple handlers when the module is imported repeatedly
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
 # 1. Create the MCP server instance
 mcp: FastMCP = FastMCP("gx-mcp-server")


### PR DESCRIPTION
## Summary
- guard against adding multiple log handlers on repeated imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f572577ac832093290c91b96409f1