### PR TITLE
Fix JSON dumps on validation detail

### DIFF
--- a/examples/ai_expectation_roundtrip.py
+++ b/examples/ai_expectation_roundtrip.py
@@ -54,4 +54,4 @@ val_res = MCP.run_checkpoint(
 )
 print("Validation ID:", val_res.validation_id)
 detail = MCP.get_validation_result(validation_id=val_res.validation_id)
-print("Validation summary:", json.dumps(detail, indent=2))
+print("Validation summary:", json.dumps(detail.model_dump(), indent=2))

--- a/examples/basic_roundtrip.py
+++ b/examples/basic_roundtrip.py
@@ -33,4 +33,4 @@ print("Validation ID:", val_res.validation_id)
 
 # 6) Fetch results
 detail = MCP.get_validation_result(validation_id=val_res.validation_id)
-print("Validation summary:", json.dumps(detail, indent=2))
+print("Validation summary:", json.dumps(detail.model_dump(), indent=2))


### PR DESCRIPTION
## Summary
- update examples to call `model_dump` before JSON serialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f672ce758832088a2abbd1b43d3a1