### PR TITLE
Fix Dockerfile uv sync flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY pyproject.toml uv.lock* ./
 RUN pip install uv
-RUN uv sync --system
+RUN uv sync
 COPY . .
 EXPOSE 8000
 CMD ["uv", "run", "python", "-m", "gx_mcp_server", "--http"]


### PR DESCRIPTION
## Summary
- remove deprecated `--system` flag from Dockerfile

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6873a7f65c4483208be2cb520d1e906f