### PR TITLE
Specify hatch build package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY pyproject.toml uv.lock* ./
+COPY pyproject.toml uv.lock* LICENSE README.md ./
 RUN pip install uv
 RUN uv sync
 COPY . .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ Homepage = "https://github.com/dfront/gx-mcp-server"
 Repository = "https://github.com/dfront/gx-mcp-server"
 Issues = "https://github.com/dfront/gx-mcp-server/issues"
 
+[tool.hatch.build.targets.wheel]
+packages = ["gx_mcp_server"]
+
 [tool.black]
 line-length = 88
 target-version = ['py311']


### PR DESCRIPTION
## Summary
- configure Hatch to include the gx_mcp_server package so `uv sync` works in Docker

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`

Docker isn't installed in this environment, so `docker build` could not be tested.

------
https://chatgpt.com/codex/tasks/task_e_6873aa8c9f088320b2bd92592f090e4a