### PR TITLE
Add project roadmap v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Set `GX_ANALYTICS_ENABLED=false` to disable telemetry.
 - **Concurrency:** Blocking/serial; no job queue or async.
 - **API may change:** Expect early-breaking changes.
 
+## Project Roadmap
+
+See [ROADMAP-v2.md](ROADMAP-v2.md) for upcoming sprints and priority labels.
+
 ## License & Contributing
 
 MIT License. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to help!

--- a/ROADMAP-v2.md
+++ b/ROADMAP-v2.md
@@ -1,0 +1,19 @@
+# Project Roadmap (v2)
+
+This document outlines upcoming development sprints and how we prioritize issues.
+
+## Priority Labels
+
+- **P0** – Must fix immediately for release stability or security.
+- **P1** – Important enhancements that should land in the next sprint.
+- **P2** – Nice-to-have improvements scheduled as time permits.
+
+## Planned Sprints
+
+| Sprint | Focus | Example Items |
+|-------|-------|---------------|
+| **Sprint 1** | Core server polish | Bug fixes, improved tests, deployment automation |
+| **Sprint 2** | Extended toolset | Additional dataset loaders, more expectation helpers |
+| **Sprint 3** | Ecosystem integration | Docker optimizations, example workflows |
+
+These plans are high level and may change as the project evolves.


### PR DESCRIPTION
## Summary
- add ROADMAP-v2 with upcoming sprints and priority label definitions
- link the roadmap from README

## Testing
- `uv run pre-commit run --files README.md ROADMAP-v2.md`
- `uv run mypy gx_mcp_server/`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68774c71d13c8320bb18cb23aa9b60cd