### PR TITLE
Add Justfile with helper tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,14 @@ We welcome all contributions: bug fixes, enhancements, docs, and tests!
    uv sync
    uv pip install -e .
    ```
+   You can also run `just install` to automatically set up `uv` in a virtual
+   environment and install all dependencies.
 3. Run formatting and tests:
    ```bash
    uv run pre-commit run --all-files
    uv run pytest
    ```
+   Or simply run `just lint` or `just test` to execute these steps.
    Or run the tests inside Docker using the provided image:
    ```bash
    docker build -t gx-mcp-server .
@@ -28,6 +31,7 @@ We welcome all contributions: bug fixes, enhancements, docs, and tests!
    ```bash
    uv run python scripts/run_examples.py
    ```
+   Use `just serve` to start the HTTP server for local testing.
 
 ## Continuous Integration
 
@@ -43,6 +47,10 @@ uv run pre-commit run --all-files
 uv run ruff check .
 uv run mypy gx_mcp_server/
 uv run pytest
+```
+The same workflow can be run via the Justfile with:
+```bash
+just install && just lint && just test
 ```
 
 ## Reporting Issues

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,27 @@
+# Task automation for gx-mcp-server
+
+# Use bash with strict options
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+# Determine uv command (global or local .venv)
+uv_cmd := `if command -v uv >/dev/null 2>&1; then echo uv; else echo .venv/bin/uv; fi`
+
+# Ensure uv is available, installing into .venv if necessary
+ensure_uv:
+    if ! command -v uv >/dev/null 2>&1; then \
+        python3 -m venv .venv && \
+        .venv/bin/pip install uv; \
+    fi
+
+install: ensure_uv
+    {{uv_cmd}} sync
+    {{uv_cmd}} pip install -e .[dev]
+
+test: ensure_uv
+    {{uv_cmd}} run pytest
+
+lint: ensure_uv
+    {{uv_cmd}} run pre-commit run --all-files
+
+serve: ensure_uv
+    {{uv_cmd}} run python -m gx_mcp_server --http

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Large Language Model (LLM) agents often need to interact with and validate data.
 - **Run server:** `uv run python -m gx_mcp_server --http`
 - **Try examples:** `uv run python scripts/run_examples.py`
 - **Test:** `uv run pytest`
+- **Convenience tasks:** `just install`, `just lint`, `just test`, `just serve`
 - **Default CSV limit:** 50 MB (`MCP_CSV_SIZE_LIMIT_MB` to change)
 
 ## Features
@@ -41,6 +42,8 @@ uv pip install -e ".[dev]"
 cp .env.example .env  # (optional: add your OpenAI API key)
 uv run python scripts/run_examples.py
 ```
+You can also use `just install` to set up the environment and `just serve` to
+start the HTTP server.
 
 ## Usage
 
@@ -103,6 +106,7 @@ uv run ruff check .
 uv run mypy gx_mcp_server/
 uv run pytest
 ```
+These steps can also be executed via `just lint` and `just test`.
 
 ## Telemetry
 


### PR DESCRIPTION
## Summary
- add a Justfile with install, test, lint and serve tasks
- note the Justfile tasks in CONTRIBUTING
- mention `just` commands in README

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv run mypy gx_mcp_server/`


------
https://chatgpt.com/codex/tasks/task_e_68774c11b1408320b7a01c78697d8a9d