### PR TITLE
Add inspector auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ uv run python scripts/run_examples.py
 
 - **Inspector GUI:**
   ```bash
+  uv run python -m gx_mcp_server --inspect [--inspector-auth <token>]
   npx @modelcontextprotocol/inspector
-  # Connect to: http://localhost:8000/mcp/
+  # Connect to: http://localhost:8000/mcp/  # append ?token=<token> if auth enabled
   ```
 
 ## Configuring Maximum CSV File Size

--- a/gx_mcp_server/__main__.py
+++ b/gx_mcp_server/__main__.py
@@ -41,6 +41,14 @@ Examples:
         action="store_true", 
         help="Run with MCP Inspector for development/testing",
     )
+
+    parser.add_argument(
+        "--inspector-auth",
+        metavar="TOKEN",
+        type=str,
+        default=None,
+        help="Authentication token for the Inspector",
+    )
     
     parser.add_argument(
         "--port",
@@ -104,7 +112,7 @@ async def run_http(host: str, port: int) -> None:
     await mcp.run_http_async(host=host, port=port)
 
 
-def show_inspector_instructions(host: str, port: int) -> None:
+def show_inspector_instructions(host: str, port: int, token: str | None = None) -> None:
     """Run MCP server with inspector for development."""
     from gx_mcp_server import logger
     
@@ -113,7 +121,10 @@ def show_inspector_instructions(host: str, port: int) -> None:
     logger.info("To use the MCP Inspector with this server:")
     logger.info("1. Start this server in HTTP mode: python -m gx_mcp_server --http")
     logger.info("2. In another terminal, run: npx @modelcontextprotocol/inspector")
-    logger.info("3. Connect the inspector to http://localhost:8000")
+    url = f"http://{host}:{port}"
+    if token:
+        url += f"?token={token}"
+    logger.info(f"3. Connect the inspector to {url}")
     
     # For now, run the server in HTTP mode as a fallback
     mcp = create_server()
@@ -128,7 +139,7 @@ def main() -> None:
     try:
         if args.inspect:
             # Inspector mode (synchronous)
-            show_inspector_instructions(args.host, args.port)
+            show_inspector_instructions(args.host, args.port, args.inspector_auth)
         elif args.http:
             # HTTP mode (async)
             asyncio.run(run_http(args.host, args.port))

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,0 +1,14 @@
+import sys
+from gx_mcp_server.__main__ import parse_args
+
+
+def test_inspector_auth_default(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog'])
+    args = parse_args()
+    assert args.inspector_auth is None
+
+
+def test_inspector_auth_value(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog', '--inspector-auth', 'secret'])
+    args = parse_args()
+    assert args.inspector_auth == 'secret'


### PR DESCRIPTION
## Summary
- add `--inspector-auth` CLI flag
- include auth token in Inspector instructions
- document token usage in README
- test parsing of the new option

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68774bffe3a48320ab8a98c28993d2c4