### PR TITLE
Add Basic Auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ start the HTTP server.
 - **HTTP mode:** For browser and API clients
 ```bash
 uv run python -m gx_mcp_server --http
+# add basic auth (e.g., user "admin" with password "secret")
+uv run python -m gx_mcp_server --http --basic-auth admin:secret
 ```
 
 *Requests per minute limit*
@@ -63,11 +65,6 @@ uv run python -m gx_mcp_server --http
 uv run python -m gx_mcp_server --http --rate-limit 30
 ```
 Default is 60 requests per minute.
-
-- **HTTP mode (localhost only):**
-  ```bash
-  uv run python -m gx_mcp_server --http --host 127.0.0.1
-  ```
 
 - **HTTP mode (localhost only):**
   ```bash
@@ -159,7 +156,7 @@ Set `GX_ANALYTICS_ENABLED=false` to disable telemetry.
 ## Future Work & Known Limitations
 
 - **No persistent storage:** Data is in-memory; lost on restart.
-- **No authentication:** Do NOT expose HTTP to untrusted networks.
+- **Optional basic auth:** Use `--basic-auth user:pass` to require credentials.
 - **No URL restrictions:** Use only in trusted environments.
 - **No resource cleanup:** Large/long sessions may use significant RAM.
 - **Concurrency:** Blocking/serial; no job queue or async.

--- a/gx_mcp_server/basic_auth.py
+++ b/gx_mcp_server/basic_auth.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import base64
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.requests import Request
+
+class BasicAuthMiddleware(BaseHTTPMiddleware):
+    """Simple HTTP Basic authentication middleware."""
+
+    def __init__(self, app, username: str, password: str) -> None:
+        super().__init__(app)
+        self._expected = f"{username}:{password}"
+
+    async def dispatch(self, request: Request, call_next):
+        auth = request.headers.get("Authorization")
+        if not auth or not auth.lower().startswith("basic "):
+            return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
+        try:
+            decoded = base64.b64decode(auth.split(" ", 1)[1]).decode()
+        except Exception:
+            return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
+        if decoded != self._expected:
+            return Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
+        return await call_next(request)

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -1,0 +1,32 @@
+import base64
+from starlette.testclient import TestClient
+from starlette.middleware import Middleware
+
+from gx_mcp_server.server import create_server
+from gx_mcp_server.basic_auth import BasicAuthMiddleware
+
+
+def create_app(use_auth: bool):
+    server = create_server()
+    middleware = []
+    if use_auth:
+        middleware.append(Middleware(BasicAuthMiddleware, username="user", password="pass"))
+    return server.http_app(middleware=middleware)
+
+
+def test_no_auth_allowed():
+    app = create_app(False)
+    with TestClient(app) as client:
+        resp = client.get("/mcp/")
+        assert resp.status_code != 401
+
+
+def test_basic_auth_required():
+    app = create_app(True)
+    with TestClient(app) as client:
+        resp = client.get("/mcp/")
+        assert resp.status_code == 401
+        token = base64.b64encode(b"user:pass").decode()
+        resp_ok = client.get("/mcp/", headers={"Authorization": f"Basic {token}"})
+        assert resp_ok.status_code != 401
+


### PR DESCRIPTION
## Summary
- support `--basic-auth` option in CLI
- implement `BasicAuthMiddleware`
- document usage of the new flag
- test authenticated and unauthenticated scenarios

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68774c26fd448320bc6a3217d46eb4c8