### PR TITLE
Add streaming option and row limit

### DIFF
--- a/gx_mcp_server/tools/datasets.py
+++ b/gx_mcp_server/tools/datasets.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Literal, Optional
 
 import pandas as pd
 
-try:  # Optional polars support for streaming
+# ``polars`` is optional and used when streaming large CSVs
+try:
     import polars as pl
     HAS_POLARS = True
 except Exception:  # pragma: no cover - polars optional

--- a/gx_mcp_server/tools/datasets.py
+++ b/gx_mcp_server/tools/datasets.py
@@ -86,10 +86,10 @@ def load_dataset(
             if use_polars and HAS_POLARS:
                 scan = pl.scan_csv(path)
                 if max_rows is not None:
-                    df = scan.fetch(max_rows)
+                    pl_df = scan.fetch(max_rows)
                 else:
-                    df = scan.collect()
-                df = df.to_pandas()
+                    pl_df = scan.collect()
+                df = pl_df.to_pandas()
             else:
                 df = pd.read_csv(path, nrows=max_rows)
         elif source_type == "url":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "great-expectations>=0.17",
     "pydantic>=1",
     "requests>=2.28",
+    # Optional streaming support
+    "polars>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,8 +8,10 @@ def test_load_and_handle():
     df = pd.DataFrame({"a": [1, 2, 3]})
     csv = df.to_csv(index=False)
     # call the underlying function
-    res = load_dataset(source=csv, source_type="inline")
+    res = load_dataset(source=csv, source_type="inline", max_rows=2)
     assert isinstance(res.handle, str)
+    loaded = DataStorage.get(res.handle)
+    assert len(loaded) == 2
 
 
 def test_load_empty_csv():

--- a/tests/test_mcp_logic.py
+++ b/tests/test_mcp_logic.py
@@ -1,12 +1,15 @@
 from gx_mcp_server.tools.datasets import load_dataset
 from gx_mcp_server.tools.expectations import add_expectation, create_suite
 from gx_mcp_server.tools.validation import get_validation_result, run_checkpoint
+from gx_mcp_server.core.storage import DataStorage
 
 
 def test_load_dataset():
     csv_data = "col1,col2\n1,a\n2,b"
-    result = load_dataset(source=csv_data, source_type="inline")
+    result = load_dataset(source=csv_data, source_type="inline", max_rows=1)
     assert result.handle is not None
+    df = DataStorage.get(result.handle)
+    assert len(df) == 1
 
 
 def test_create_suite():


### PR DESCRIPTION
## Summary
- optionally stream CSVs using `polars.scan_csv`
- support new `max_rows` argument on `load_dataset`
- test dataset loading with the row limit

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68774c48eb2c832098fa54787fb1e28c