### PR TITLE
Add SQLite persistence option

### DIFF
--- a/gx_mcp_server/__main__.py
+++ b/gx_mcp_server/__main__.py
@@ -62,7 +62,14 @@ Examples:
         default="INFO",
         help="Logging level (default: INFO)",
     )
-    
+
+    parser.add_argument(
+        "--storage-backend",
+        type=str,
+        default="memory",
+        help="Storage backend URI (default: memory). Use sqlite:///path/to/gx.db",
+    )
+
     return parser.parse_args()
 
 
@@ -124,6 +131,9 @@ def main() -> None:
     """Main entry point."""
     args = parse_args()
     setup_logging(args.log_level)
+    from gx_mcp_server.core import storage
+
+    storage.configure_storage_backend(args.storage_backend)
     
     try:
         if args.inspect:

--- a/gx_mcp_server/core/storage.py
+++ b/gx_mcp_server/core/storage.py
@@ -1,20 +1,27 @@
 # gx_mcp_server/core/storage.py
+"""Storage backends for datasets and validation results."""
+
+from __future__ import annotations
+
+import threading
 import uuid
 from collections import OrderedDict
 from typing import Any
-import threading
 
 import pandas as pd
 
-# in-memory stores
+_MAX_ITEMS = 100
+
+# ---------------------------------------------------------------------------
+# In-memory implementation
+# ---------------------------------------------------------------------------
 _df_store: OrderedDict[str, pd.DataFrame] = OrderedDict()
 _result_store: OrderedDict[str, Any] = OrderedDict()
 _df_lock = threading.Lock()
 _result_lock = threading.Lock()
-_MAX_ITEMS = 100
 
 
-class DataStorage:
+class _InMemoryDataStorage:
     @staticmethod
     def add(df: pd.DataFrame) -> str:
         handle = str(uuid.uuid4())
@@ -37,7 +44,7 @@ class DataStorage:
         return path
 
 
-class ValidationStorage:
+class _InMemoryValidationStorage:
     @staticmethod
     def add(result: Any) -> str:
         vid = str(uuid.uuid4())
@@ -51,3 +58,53 @@ class ValidationStorage:
     def get(vid: str) -> Any:
         with _result_lock:
             return _result_store[vid]
+
+
+# ---------------------------------------------------------------------------
+# Dynamic backend dispatch
+# ---------------------------------------------------------------------------
+_data_backend: type[_InMemoryDataStorage] | Any = _InMemoryDataStorage
+_validation_backend: type[_InMemoryValidationStorage] | Any = _InMemoryValidationStorage
+
+
+def configure_storage_backend(uri: str) -> None:
+    """Configure storage backend based on URI."""
+    global _data_backend, _validation_backend
+
+    if uri.startswith("sqlite:///"):
+        from gx_mcp_server.storage import sqlite_backend
+
+        sqlite_backend.initialize(uri)
+        _data_backend = sqlite_backend.DataStorage
+        _validation_backend = sqlite_backend.ValidationStorage
+    else:
+        _data_backend = _InMemoryDataStorage
+        _validation_backend = _InMemoryValidationStorage
+
+
+class DataStorage:
+    """Facade for the configured DataStorage backend."""
+
+    @staticmethod
+    def add(df: pd.DataFrame) -> str:
+        return _data_backend.add(df)
+
+    @staticmethod
+    def get(handle: str) -> pd.DataFrame:
+        return _data_backend.get(handle)
+
+    @staticmethod
+    def get_handle_path(handle: str) -> str:
+        return _data_backend.get_handle_path(handle)
+
+
+class ValidationStorage:
+    """Facade for the configured ValidationStorage backend."""
+
+    @staticmethod
+    def add(result: Any) -> str:
+        return _validation_backend.add(result)
+
+    @staticmethod
+    def get(vid: str) -> Any:
+        return _validation_backend.get(vid)

--- a/gx_mcp_server/storage/sqlite_backend.py
+++ b/gx_mcp_server/storage/sqlite_backend.py
@@ -1,0 +1,109 @@
+import os
+import sqlite3
+import threading
+import uuid
+import pickle
+from typing import Any
+
+import pandas as pd
+
+_conn: sqlite3.Connection | None = None
+_db_path: str | None = None
+_lock = threading.Lock()
+_MAX_ITEMS = 100
+
+
+def initialize(uri: str) -> None:
+    """Initialize the SQLite backend given a URI like sqlite:///path/to/db."""
+    global _conn, _db_path
+    path = uri[len("sqlite:///") :]
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    _db_path = path
+    if _conn is not None:
+        _conn.close()
+    _conn = sqlite3.connect(path, check_same_thread=False)
+    _conn.execute(
+        "CREATE TABLE IF NOT EXISTS datasets (id TEXT PRIMARY KEY, data BLOB, created INTEGER)"
+    )
+    _conn.execute(
+        "CREATE TABLE IF NOT EXISTS validations (id TEXT PRIMARY KEY, data BLOB, created INTEGER)"
+    )
+    _conn.commit()
+
+
+def _get_conn() -> sqlite3.Connection:
+    if _conn is None:
+        if _db_path is None:
+            raise RuntimeError("SQLite backend not initialized")
+        initialize(f"sqlite:///{_db_path}")
+    assert _conn is not None
+    return _conn
+
+
+class DataStorage:
+    @staticmethod
+    def add(df: pd.DataFrame) -> str:
+        handle = str(uuid.uuid4())
+        blob = pickle.dumps(df)
+        with _lock:
+            conn = _get_conn()
+            conn.execute(
+                "INSERT INTO datasets (id, data, created) VALUES (?, ?, strftime('%s','now'))",
+                (handle, blob),
+            )
+            conn.commit()
+            count = conn.execute("SELECT COUNT(*) FROM datasets").fetchone()[0]
+            if count > _MAX_ITEMS:
+                to_delete = conn.execute(
+                    "SELECT id FROM datasets ORDER BY created ASC LIMIT ?",
+                    (count - _MAX_ITEMS,),
+                ).fetchall()
+                conn.executemany("DELETE FROM datasets WHERE id = ?", to_delete)
+                conn.commit()
+        return handle
+
+    @staticmethod
+    def get(handle: str) -> pd.DataFrame:
+        conn = _get_conn()
+        row = conn.execute("SELECT data FROM datasets WHERE id=?", (handle,)).fetchone()
+        if row is None:
+            raise KeyError(handle)
+        return pickle.loads(row[0])
+
+    @staticmethod
+    def get_handle_path(handle: str) -> str:
+        df = DataStorage.get(handle)
+        path = f"/tmp/{handle}.csv"
+        df.to_csv(path, index=False)
+        return path
+
+
+class ValidationStorage:
+    @staticmethod
+    def add(result: Any) -> str:
+        vid = str(uuid.uuid4())
+        blob = pickle.dumps(result)
+        with _lock:
+            conn = _get_conn()
+            conn.execute(
+                "INSERT INTO validations (id, data, created) VALUES (?, ?, strftime('%s','now'))",
+                (vid, blob),
+            )
+            conn.commit()
+            count = conn.execute("SELECT COUNT(*) FROM validations").fetchone()[0]
+            if count > _MAX_ITEMS:
+                to_delete = conn.execute(
+                    "SELECT id FROM validations ORDER BY created ASC LIMIT ?",
+                    (count - _MAX_ITEMS,),
+                ).fetchall()
+                conn.executemany("DELETE FROM validations WHERE id = ?", to_delete)
+                conn.commit()
+        return vid
+
+    @staticmethod
+    def get(vid: str) -> Any:
+        conn = _get_conn()
+        row = conn.execute("SELECT data FROM validations WHERE id=?", (vid,)).fetchone()
+        if row is None:
+            raise KeyError(vid)
+        return pickle.loads(row[0])

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from gx_mcp_server.core import storage
+
+
+def test_sqlite_persistence(tmp_path):
+    db_path = tmp_path / "gx.db"
+    storage.configure_storage_backend(f"sqlite:///{db_path}")
+
+    df = pd.DataFrame({"a": [1, 2]})
+    handle = storage.DataStorage.add(df)
+    vid = storage.ValidationStorage.add({"ok": True})
+
+    # Reinitialize to simulate a new process
+    storage.configure_storage_backend(f"sqlite:///{db_path}")
+
+    df_loaded = storage.DataStorage.get(handle)
+    assert df_loaded.equals(df)
+
+    result_loaded = storage.ValidationStorage.get(vid)
+    assert result_loaded == {"ok": True}


### PR DESCRIPTION
## Summary
- implement configurable storage backends
- add SQLite backend with basic persistence
- expose `--storage-backend` CLI flag
- test SQLite persistence

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68774c30d7588320b31e6a27f4c97bd4