### PR TITLE
Add async validation background tasks

### DIFF
--- a/gx_mcp_server/core/storage.py
+++ b/gx_mcp_server/core/storage.py
@@ -38,8 +38,11 @@ class DataStorage:
 
 
 class ValidationStorage:
-    @staticmethod
-    def add(result: Any) -> str:
+    """Simple in-memory store for validation results."""
+
+    @classmethod
+    def add(cls, result: Any) -> str:
+        """Add a completed validation result and return its ID."""
         vid = str(uuid.uuid4())
         with _result_lock:
             if len(_result_store) >= _MAX_ITEMS:
@@ -47,8 +50,8 @@ class ValidationStorage:
             _result_store[vid] = result
         return vid
 
-    @staticmethod
-    def reserve() -> str:
+    @classmethod
+    def reserve(cls) -> str:
         """Reserve an ID for an asynchronous validation run."""
         vid = str(uuid.uuid4())
         with _result_lock:
@@ -57,13 +60,14 @@ class ValidationStorage:
             _result_store[vid] = {"status": "pending"}
         return vid
 
-    @staticmethod
-    def set(vid: str, result: Any) -> None:
+    @classmethod
+    def set(cls, vid: str, result: Any) -> None:
         """Store a validation result for a pre-reserved ID."""
         with _result_lock:
             _result_store[vid] = result
 
-    @staticmethod
-    def get(vid: str) -> Any:
+    @classmethod
+    def get(cls, vid: str) -> Any:
+        """Retrieve a stored validation result by ID."""
         with _result_lock:
             return _result_store[vid]

--- a/gx_mcp_server/core/storage.py
+++ b/gx_mcp_server/core/storage.py
@@ -48,6 +48,22 @@ class ValidationStorage:
         return vid
 
     @staticmethod
+    def reserve() -> str:
+        """Reserve an ID for an asynchronous validation run."""
+        vid = str(uuid.uuid4())
+        with _result_lock:
+            if len(_result_store) >= _MAX_ITEMS:
+                _result_store.popitem(last=False)
+            _result_store[vid] = {"status": "pending"}
+        return vid
+
+    @staticmethod
+    def set(vid: str, result: Any) -> None:
+        """Store a validation result for a pre-reserved ID."""
+        with _result_lock:
+            _result_store[vid] = result
+
+    @staticmethod
     def get(vid: str) -> Any:
         with _result_lock:
             return _result_store[vid]

--- a/gx_mcp_server/tools/validation.py
+++ b/gx_mcp_server/tools/validation.py
@@ -1,5 +1,7 @@
 # gx_mcp_server/tools/validation.py
 from typing import TYPE_CHECKING, Optional
+import asyncio
+from typing import Any
 
 from great_expectations.core.batch import Batch, RuntimeBatchRequest
 from great_expectations.exceptions import DataContextError
@@ -10,6 +12,72 @@ from gx_mcp_server.logging import logger
 from gx_mcp_server.core import schema, storage
 from gx_mcp_server.core.context import get_shared_context
 
+
+def _execute_validation(
+    suite_name: str, dataset_handle: str, checkpoint_name: Optional[str] = None
+) -> dict:
+    """Execute a validation synchronously and return the result dict."""
+    logger.info(
+        "Running checkpoint for suite '%s' with dataset_handle '%s'",
+        suite_name,
+        dataset_handle,
+    )
+
+    # For dummy handles or missing dataset, skip GE and return success
+    try:
+        df = storage.DataStorage.get(dataset_handle)
+    except KeyError:
+        logger.warning(
+            "Dataset handle '%s' not found, returning dummy success result",
+            dataset_handle,
+        )
+        return {"statistics": {}, "results": [], "success": True}
+
+    try:
+        context = get_shared_context()
+        suite = context.suites.get(suite_name)
+        logger.info(
+            "Retrieved suite '%s' with %d expectations",
+            suite_name,
+            len(suite.expectations),
+        )
+    except DataContextError as e:
+        logger.warning("Suite '%s' not found in current context: %s", suite_name, str(e))
+        logger.info("This is expected in MCP servers where contexts don't persist across calls")
+        return {
+            "statistics": {"evaluated_expectations": 0},
+            "results": [],
+            "success": True,
+            "note": (
+                f"Suite '{suite_name}' was created but validation context is ephemeral. "
+                "In production, use persistent data contexts."
+            ),
+        }
+    except Exception as e:
+        logger.error("Unexpected error during validation: %s", str(e))
+        return {
+            "statistics": {"evaluated_expectations": 0},
+            "results": [],
+            "success": False,
+            "error": f"Validation failed: {str(e)}",
+        }
+
+    execution_engine = PandasExecutionEngine()
+    batch_request = RuntimeBatchRequest(
+        datasource_name="runtime_pandas_datasource",
+        data_connector_name="default_runtime_data_connector_name",
+        data_asset_name=f"asset_{dataset_handle}",
+        runtime_parameters={"batch_data": df},
+        batch_identifiers={"default_identifier_name": "default_identifier"},
+    )
+    validator = Validator(
+        execution_engine=execution_engine,
+        expectation_suite=suite,
+        batches=[Batch(data=df, batch_request=batch_request)],  # type: ignore[arg-type]
+    )
+    validation_result = validator.validate()
+    return validation_result.to_json_dict()
+
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
@@ -18,6 +86,7 @@ def run_checkpoint(
     suite_name: str,
     dataset_handle: str,
     checkpoint_name: Optional[str] = None,
+    background_tasks: Any | None = None,
 ) -> schema.ValidationResult:
     """Run a validation checkpoint against a dataset using an expectation suite.
 
@@ -32,86 +101,22 @@ def run_checkpoint(
     Note:
         Use get_validation_result() with the returned validation_id to get detailed results.
     """
-    logger.info(
-        "Running checkpoint for suite '%s' with dataset_handle '%s'",
-        suite_name,
-        dataset_handle,
-    )
-
-    # For dummy handles or missing dataset, skip GE and return success
-    try:
-        df = storage.DataStorage.get(dataset_handle)
-    except KeyError:
-        logger.warning(  # type: ignore[unreachable]
-            "Dataset handle '%s' not found, returning dummy success result",
-            dataset_handle,
-        )
-        dummy = {"statistics": {}, "results": [], "success": True}
-        vid = storage.ValidationStorage.add(dummy)
+    if background_tasks is None:
+        result_dict = _execute_validation(suite_name, dataset_handle, checkpoint_name)
+        vid = storage.ValidationStorage.add(result_dict)
+        logger.info("Validation completed with ID: %s", vid)
         return schema.ValidationResult(validation_id=vid)
 
-    try:
-        context = get_shared_context()
-        suite = context.suites.get(suite_name)
-        logger.info(
-            "Retrieved suite '%s' with %d expectations",
-            suite_name,
-            len(suite.expectations),
+    vid = storage.ValidationStorage.reserve()
+
+    async def _task() -> None:
+        result = await asyncio.to_thread(
+            _execute_validation, suite_name, dataset_handle, checkpoint_name
         )
-    except DataContextError as e:
-        logger.warning(
-            "Suite '%s' not found in current context: %s", suite_name, str(e)
-        )
-        logger.info(
-            "This is expected in MCP servers where contexts don't persist across calls"
-        )
-        # Return a success result with note about non-persistent context
-        error_result = {
-            "statistics": {"evaluated_expectations": 0},
-            "results": [],
-            "success": True,
-            "note": f"Suite '{suite_name}' was created but validation context is ephemeral. In production, use persistent data contexts.",
-        }
-        vid = storage.ValidationStorage.add(error_result)
-        return schema.ValidationResult(validation_id=vid)
-    except Exception as e:
-        logger.error("Unexpected error during validation: %s", str(e))
-        error_result = {
-            "statistics": {"evaluated_expectations": 0},
-            "results": [],
-            "success": False,
-            "error": f"Validation failed: {str(e)}",
-        }
-        vid = storage.ValidationStorage.add(error_result)
-        return schema.ValidationResult(validation_id=vid)
+        storage.ValidationStorage.set(vid, result)
 
-    # This is the most direct, low-level V3 API approach that avoids
-    # DataContext methods that might be trying to be "smart" about API versions.
-
-    # 1. Manually create an execution engine
-    execution_engine = PandasExecutionEngine()
-
-    # 2. Create a RuntimeBatchRequest for the in-memory data
-    batch_request = RuntimeBatchRequest(
-        datasource_name="runtime_pandas_datasource",  # a logical name
-        data_connector_name="default_runtime_data_connector_name",  # a logical name
-        data_asset_name=f"asset_{dataset_handle}",  # a logical name
-        runtime_parameters={"batch_data": df},
-        batch_identifiers={"default_identifier_name": "default_identifier"},
-    )
-
-    # 3. Instantiate the Validator directly
-    validator = Validator(
-        execution_engine=execution_engine,
-        expectation_suite=suite,
-        batches=[Batch(data=df, batch_request=batch_request)],  # type: ignore[arg-type]
-    )
-
-    # 4. Run validation and store the result
-    validation_result = validator.validate()
-    result_dict = validation_result.to_json_dict()
-    vid = storage.ValidationStorage.add(result_dict)
-    logger.info("Validation completed with ID: %s", vid)
+    background_tasks.add_task(_task)
+    logger.info("Validation scheduled asynchronously with ID: %s", vid)
     return schema.ValidationResult(validation_id=vid)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pandas-stubs",
     "openai",
     "python-dotenv",
+    "fastapi",
 ]
 
 [project.scripts]
@@ -83,8 +84,6 @@ python_functions = ["test_*"]
 addopts = "-v --tb=short"
 asyncio_mode = "auto"
 filterwarnings = [
-    # Suppress harmless warnings from Great Expectations
-    "ignore::marshmallow.warnings.ChangedInMarshmallow4Warning",
     "ignore:.*Number.*field should not be instantiated.*",
 ]
 

--- a/tests/test_parallel_validation.py
+++ b/tests/test_parallel_validation.py
@@ -1,0 +1,32 @@
+import asyncio
+import pytest
+from fastapi import BackgroundTasks
+
+from gx_mcp_server.tools.expectations import create_suite, add_expectation
+from gx_mcp_server.tools.datasets import load_dataset
+from gx_mcp_server.tools.validation import run_checkpoint, get_validation_result
+
+@pytest.mark.asyncio
+async def test_concurrent_validations():
+    create_suite(suite_name="async_suite", dataset_handle="dummy", profiler=False)
+    add_expectation(
+        suite_name="async_suite",
+        expectation_type="expect_column_to_exist",
+        kwargs={"column": "a"},
+    )
+
+    handle1 = load_dataset("a\n1", source_type="inline").handle
+    handle2 = load_dataset("a\n2", source_type="inline").handle
+
+    bgs = [BackgroundTasks(), BackgroundTasks()]
+    results = await asyncio.gather(
+        asyncio.to_thread(run_checkpoint, "async_suite", handle1, background_tasks=bgs[0]),
+        asyncio.to_thread(run_checkpoint, "async_suite", handle2, background_tasks=bgs[1]),
+    )
+
+    await asyncio.gather(*(bg() for bg in bgs))
+
+    for res in results:
+        detail = get_validation_result(res.validation_id)
+        assert detail.success is True
+


### PR DESCRIPTION
## Summary
- add `reserve` and `set` helpers in `ValidationStorage`
- run validations as `BackgroundTasks` if provided
- add concurrency test for validations
- drop temporary mypy ignores

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `mypy gx_mcp_server/`


------
https://chatgpt.com/codex/tasks/task_e_68774c60a7408320b27e9203a2a1fac1