### PR TITLE
Add metrics endpoint and optional tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ uv run python -m gx_mcp_server --http
 ```
 Allowed values: 1–1024 MB.
 
+## Metrics and Tracing
+
+- Prometheus metrics exposed on `--metrics-port` (default **9090**).
+- Enable OpenTelemetry tracing with `--trace`. When enabled, logs include
+  `OTEL_RESOURCE_ATTRIBUTES` and spans are exported via OTLP.
+
 ## Docker
 
 To build and run with Docker (Python and uv included):

--- a/gx_mcp_server/__main__.py
+++ b/gx_mcp_server/__main__.py
@@ -13,12 +13,12 @@ import argparse
 import asyncio
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from gx_mcp_server.server import create_server
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
-    from starlette.types import ASGIApp
+    pass
 
 
 def parse_args() -> argparse.Namespace:
@@ -115,13 +115,14 @@ async def run_stdio() -> None:
     await mcp.run_stdio_async()
 
 
-def setup_tracing(app: "ASGIApp") -> None:
+def setup_tracing(app: Any) -> None:
     """Configure OpenTelemetry tracing."""
     from opentelemetry import trace
     from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
     resource = Resource.create({"service.name": "gx-mcp-server"})
     provider = TracerProvider(resource=resource)

--- a/gx_mcp_server/logging.py
+++ b/gx_mcp_server/logging.py
@@ -1,5 +1,6 @@
 # gx_mcp_server/logging.py
 import logging
+import os
 import warnings
 
 # Suppress Great Expectations Marshmallow warnings
@@ -17,10 +18,17 @@ warnings.filterwarnings(
 logger = logging.getLogger("gx_mcp_server")
 
 # Avoid adding multiple handlers when the module is imported repeatedly
+class _OTelFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.otel = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
+        return True
+
+
 if not logger.handlers:
     handler = logging.StreamHandler()
+    handler.addFilter(_OTelFilter())
     handler.setFormatter(
-        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s %(otel)s: %(message)s")
     )
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "great-expectations>=0.17",
     "pydantic>=1",
     "requests>=2.28",
+    "prometheus-fastapi-instrumentator>=7",
+    "opentelemetry-sdk>=1",
+    "opentelemetry-exporter-otlp>=1",
+    "opentelemetry-instrumentation-fastapi>=0.46",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- expose Prometheus metrics using `prometheus-fastapi-instrumentator`
- add optional OpenTelemetry tracing via `--trace`
- show OTEL attributes in structured logs
- document new observability options

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv run python scripts/run_examples.py`

------
https://chatgpt.com/codex/tasks/task_e_68774c6dbe78832087747794641fb6af