### PR TITLE
Add metrics endpoint and optional tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ uv run python -m gx_mcp_server --http
 ```
 Allowed values: 1–1024 MB.
 
+## Metrics and Tracing
+
+- Prometheus metrics exposed on `--metrics-port` (default **9090**).
+- Enable OpenTelemetry tracing with `--trace`. When enabled, logs include
+  `OTEL_RESOURCE_ATTRIBUTES` and spans are exported via OTLP.
+
 ## Docker
 
 To build and run with Docker (Python and uv included):

--- a/gx_mcp_server/__main__.py
+++ b/gx_mcp_server/__main__.py
@@ -11,9 +11,16 @@ Supports multiple transport modes:
 
 import argparse
 import asyncio
+import os
 import sys
+from typing import TYPE_CHECKING, Any
+
+from fastmcp.server.http import StarletteWithLifespan
 
 from gx_mcp_server.server import create_server
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    pass
 
 
 def parse_args() -> argparse.Namespace:
@@ -62,6 +69,17 @@ Examples:
         default="INFO",
         help="Logging level (default: INFO)",
     )
+    parser.add_argument(
+        "--metrics-port",
+        type=int,
+        default=9090,
+        help="Port to expose Prometheus metrics (default: 9090)",
+    )
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Enable OpenTelemetry tracing",
+    )
     
     return parser.parse_args()
 
@@ -69,13 +87,19 @@ Examples:
 def setup_logging(level: str) -> None:
     """Configure logging for the application."""
     import logging
-    
+
+    class OTelFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+            record.otel = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
+            return True
+
     # Configure root logger
     logging.basicConfig(
         level=getattr(logging, level),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        format="%(asctime)s [%(levelname)s] %(name)s %(otel)s: %(message)s",
         handlers=[logging.StreamHandler(sys.stderr)],
     )
+    logging.getLogger().addFilter(OTelFilter())
     
     # Reduce noise from some libraries
     logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -93,15 +117,51 @@ async def run_stdio() -> None:
     await mcp.run_stdio_async()
 
 
-async def run_http(host: str, port: int) -> None:
+def setup_tracing(app: Any) -> None:
+    """Configure OpenTelemetry tracing."""
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+    resource = Resource.create({"service.name": "gx-mcp-server"})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    app.add_middleware(OpenTelemetryMiddleware)
+
+
+async def run_http(host: str, port: int, metrics_port: int, trace_enabled: bool) -> None:
     """Run MCP server in HTTP mode."""
     from gx_mcp_server import logger
-    
+
     logger.info(f"Starting GX MCP Server in HTTP mode on {host}:{port}")
     mcp = create_server()
-    
-    # Run the server in HTTP mode
-    await mcp.run_http_async(host=host, port=port)
+    app: StarletteWithLifespan = mcp.http_app()
+
+    if trace_enabled:
+        setup_tracing(app)
+
+    from prometheus_fastapi_instrumentator import Instrumentator
+    from starlette.applications import Starlette
+
+    instrumentator = Instrumentator().instrument(app)
+    metrics_app = Starlette()
+    instrumentator.expose(metrics_app, include_in_schema=False)
+
+    import uvicorn
+
+    config_main = uvicorn.Config(app, host=host, port=port, timeout_graceful_shutdown=0)
+    server_main = uvicorn.Server(config_main)
+
+    config_metrics = uvicorn.Config(metrics_app, host=host, port=metrics_port, log_level="info")
+    server_metrics = uvicorn.Server(config_metrics)
+
+    logger.info(f"Metrics available at http://{host}:{metrics_port}/metrics")
+
+    await asyncio.gather(server_main.serve(), server_metrics.serve())
 
 
 def show_inspector_instructions(host: str, port: int) -> None:
@@ -123,6 +183,8 @@ def show_inspector_instructions(host: str, port: int) -> None:
 def main() -> None:
     """Main entry point."""
     args = parse_args()
+    if args.trace:
+        os.environ.setdefault("OTEL_RESOURCE_ATTRIBUTES", "service.name=gx-mcp-server")
     setup_logging(args.log_level)
     
     try:
@@ -131,7 +193,7 @@ def main() -> None:
             show_inspector_instructions(args.host, args.port)
         elif args.http:
             # HTTP mode (async)
-            asyncio.run(run_http(args.host, args.port))
+            asyncio.run(run_http(args.host, args.port, args.metrics_port, args.trace))
         else:
             # STDIO mode (async, default)
             asyncio.run(run_stdio())

--- a/gx_mcp_server/logging.py
+++ b/gx_mcp_server/logging.py
@@ -1,5 +1,6 @@
 # gx_mcp_server/logging.py
 import logging
+import os
 import warnings
 
 # Suppress Great Expectations Marshmallow warnings
@@ -17,10 +18,17 @@ warnings.filterwarnings(
 logger = logging.getLogger("gx_mcp_server")
 
 # Avoid adding multiple handlers when the module is imported repeatedly
+class _OTelFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.otel = os.getenv("OTEL_RESOURCE_ATTRIBUTES", "")
+        return True
+
+
 if not logger.handlers:
     handler = logging.StreamHandler()
+    handler.addFilter(_OTelFilter())
     handler.setFormatter(
-        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s %(otel)s: %(message)s")
     )
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "great-expectations>=0.17",
     "pydantic>=1",
     "requests>=2.28",
+    "prometheus-fastapi-instrumentator>=7",
+    "opentelemetry-sdk>=1",
+    "opentelemetry-exporter-otlp>=1",
+    "opentelemetry-instrumentation-fastapi>=0.46",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- expose Prometheus metrics using `prometheus-fastapi-instrumentator`
- add optional OpenTelemetry tracing via `--trace`
- show OTEL attributes in structured logs
- document new observability options
- fix typing for metrics server

## Testing
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv run mypy gx_mcp_server`
- `uv run python scripts/run_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68774c6dbe78832087747794641fb6af